### PR TITLE
Fix genai and edge-ml color mapping consistency

### DIFF
--- a/assets/css/graph.css
+++ b/assets/css/graph.css
@@ -70,13 +70,13 @@
 
 /* Node Categories - Color Coding */
 .node.category-genai circle {
-    fill: #6366f1;
-    stroke: #4f46e5;
+    fill: #a855f7;
+    stroke: #9333ea;
 }
 
 .node.category-edge-ml circle {
-    fill: #8b5cf6;
-    stroke: #7c3aed;
+    fill: #3b82f6;
+    stroke: #2563eb;
 }
 
 .node.category-deep-learning circle {

--- a/notes/note.html
+++ b/notes/note.html
@@ -144,12 +144,13 @@
     <script src="../assets/js/main.js"></script>
     <script>
         const FALLBACK_COLORS = {
-            'genai': '#6366f1',
-            'edge-ml': '#8b5cf6',
-            'deep-learning': '#ec4899',
-            'machine-learning': '#14b8a6',
-            'conference': '#f59e0b',
-            'visualization': '#06b6d4'
+            'deep-learning': '#ec4899',      // Pink - stands out
+            'edge-ml': '#3b82f6',            // Blue - classic tech
+            'machine-learning': '#10b981',   // Emerald - fresh green
+            'genai': '#a855f7',              // Purple - AI/futuristic
+            'visualization': '#06b6d4',      // Cyan - data/charts
+            'conference': '#f97316',         // Orange - events/energy
+            'default': '#6b7280'
         };
 
         document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- Align graph category CSS colors with the shared palette so genai renders purple and edge-ml renders blue
- Update note page fallback color definitions to stay consistent with the global category palette

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d70875d4c8331b6b681ef91355c5b)